### PR TITLE
style: center bottom navigation use-cases

### DIFF
--- a/lib/ui/widgets/navigation_item.dart
+++ b/lib/ui/widgets/navigation_item.dart
@@ -19,6 +19,7 @@ class NavigationItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Column(
+      mainAxisSize: MainAxisSize.min,
       children: [
         if (isSelected) Icon(iconSelected) else Icon(iconUnselected),
         Text(text),


### PR DESCRIPTION
The `BottomNavigationBar` and `BottomNavigationBar` use-cases were aligned to top because of the infinite height of the column used in `BottomNavigationBar`.

To make our catalog bit more consistent, they are now centred like other use-cases.